### PR TITLE
Make compatible with React Native 0.52.2

### DIFF
--- a/ios/ReactNativeConfig/ReactNativeConfig.h
+++ b/ios/ReactNativeConfig/ReactNativeConfig.h
@@ -1,4 +1,8 @@
-#import "RCTBridgeModule.h"
+#if __has_include(<React/RCTBridgeModule.h>)
+  #import <React/RCTBridgeModule.h>
+#else
+  #import "RCTBridgeModule.h"
+#endif
 
 @interface ReactNativeConfig : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
I needed to add this in order for Xcode to build the app successfully. Similar to https://github.com/ivpusic/react-native-image-crop-picker/issues/436